### PR TITLE
WDP220601-5

### DIFF
--- a/src/components/common/Button/Button.module.scss
+++ b/src/components/common/Button/Button.module.scss
@@ -35,7 +35,13 @@
   line-height: 22px;
 
   &:not(.noHover):hover {
-    background-color: #2a2a2a;
+    background-color: $primary;
     color: #ffffff;
   }
 }
+
+.active {
+  @extend .outline;
+    color: #ffffff;
+    background-color: $primary;
+  }

--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -11,7 +11,7 @@ import {
 import { faStar as farStar, faHeart } from '@fortawesome/free-regular-svg-icons';
 import Button from '../Button/Button';
 
-const ProductBox = ({ name, price, promo, stars, oldPrice }) => (
+const ProductBox = ({ name, price, promo, stars, oldPrice, favorite, compare }) => (
   <div className={styles.root}>
     <div className={styles.photo}>
       {promo && <div className={styles.sale}>{promo}</div>}
@@ -39,10 +39,10 @@ const ProductBox = ({ name, price, promo, stars, oldPrice }) => (
     <div className={styles.line}></div>
     <div className={styles.actions}>
       <div className={styles.outlines}>
-        <Button variant='outline'>
+        <Button variant={favorite ? 'active' : 'outline'}>
           <FontAwesomeIcon icon={faHeart}>Favorite</FontAwesomeIcon>
         </Button>
-        <Button variant='outline'>
+        <Button variant={compare ? 'active' : 'outline'}>
           <FontAwesomeIcon icon={faExchangeAlt}>Add to compare</FontAwesomeIcon>
         </Button>
       </div>
@@ -65,6 +65,8 @@ ProductBox.propTypes = {
   promo: PropTypes.string,
   stars: PropTypes.number,
   oldPrice: PropTypes.number,
+  favorite: PropTypes.bool,
+  compare: PropTypes.bool,
 };
 
 export default ProductBox;

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -15,6 +15,8 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      favorite: false,
+      compare: false,
     },
     {
       id: 'aenean-ru-bristique-2',
@@ -24,6 +26,8 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      favorite: true,
+      compare: false,
     },
     {
       id: 'aenean-ru-bristique-3',
@@ -33,6 +37,8 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      favorite: false,
+      compare: true,
     },
     {
       id: 'aenean-ru-bristique-4',
@@ -42,6 +48,8 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      favorite: true,
+      compare: true,
     },
     {
       id: 'aenean-ru-bristique-5',


### PR DESCRIPTION
Brak ostylowanych stanów "ulubiony" oraz "dodany do porównania".

Dodałę klasę .active dla tych buttonów zależną od wartości propsów "favorite " oraz "compare".
Klasa ta rozszerza klasę outline i w przypadku gdy jest to produkt favorite lub/i compare zamienia ją.
Dla pokazania efektu dodałem do pierwszych czterech produktów w initialStates props favorite oraz compare z różnymi wartościami true oraz false.
Rozszerzyłem ProductBox.propTypes o te dwa propsy.