### PR TITLE
Select: change font, add outline:none and add select:hover

### DIFF
--- a/src/components/features/ProductSearch/ProductSearch.module.scss
+++ b/src/components/features/ProductSearch/ProductSearch.module.scss
@@ -32,6 +32,11 @@
       padding: 5px 30px 5px 35px;
       position: relative;
       z-index: 1;
+      outline: none;
+      font-size: 14px;
+    }
+    select:hover {
+      font-weight: 800;
     }
   }
 


### PR DESCRIPTION
Select w ProductSearch był nieprawidłowo ostylowany.
Zmieniłam czcionkę, dodałam outline: none, oraz hover.