### PR TITLE
WDP220601-11

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import styles from './ProductBox.module.scss';
@@ -12,53 +12,67 @@ import { faStar as farStar, faHeart } from '@fortawesome/free-regular-svg-icons'
 import Button from '../Button/Button';
 import ProductImage from '../ProductImage/ProductImage';
 
-const ProductBox = ({ name, price, promo, stars, oldPrice, id, favorite, compare }) => (
-  <div className={styles.root}>
-    <div className={styles.photo}>
-      <ProductImage id={id} />
-      {promo && <div className={styles.sale}>{promo}</div>}
-      <div className={styles.buttons}>
-        <Button variant='small'>Quick View</Button>
-        <Button variant='small'>
-          <FontAwesomeIcon icon={faShoppingBasket}></FontAwesomeIcon> ADD TO CART
-        </Button>
-      </div>
-    </div>
-    <div className={styles.content}>
-      <h5>{name}</h5>
-      <div className={styles.stars}>
-        {[1, 2, 3, 4, 5].map(i => (
-          <a key={i} href='#'>
-            {i <= stars ? (
-              <FontAwesomeIcon icon={faStar}>{i} stars</FontAwesomeIcon>
-            ) : (
-              <FontAwesomeIcon icon={farStar}>{i} stars</FontAwesomeIcon>
-            )}
-          </a>
-        ))}
-      </div>
-    </div>
-    <div className={styles.line}></div>
-    <div className={styles.actions}>
-      <div className={styles.outlines}>
-        <Button variant={favorite ? 'active' : 'outline'}>
-          <FontAwesomeIcon icon={faHeart}>Favorite</FontAwesomeIcon>
-        </Button>
-        <Button variant={compare ? 'active' : 'outline'}>
-          <FontAwesomeIcon icon={faExchangeAlt}>Add to compare</FontAwesomeIcon>
-        </Button>
-      </div>
-      <div className={oldPrice ? styles.priceBox : ''}>
-        {oldPrice && <p>$ {oldPrice}</p>}
-        <div className={styles.price}>
-          <Button noHover variant='small' className={styles.priceButton}>
-            $ {price}
+import { useDispatch } from 'react-redux';
+import { setFavorite } from '../../../redux/productsRedux';
+
+const ProductBox = ({ name, price, promo, stars, oldPrice, id, favorite, compare }) => {
+  const dispatch = useDispatch();
+  const [isFavorite, setIsFavorite] = useState(favorite || false);
+
+  const changeFavorite = e => {
+    e.preventDefault();
+    setIsFavorite(!isFavorite);
+    dispatch(setFavorite({ id, favorite: isFavorite }));
+  };
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.photo}>
+        <ProductImage id={id} />
+        {promo && <div className={styles.sale}>{promo}</div>}
+        <div className={styles.buttons}>
+          <Button variant='small'>Quick View</Button>
+          <Button variant='small'>
+            <FontAwesomeIcon icon={faShoppingBasket}></FontAwesomeIcon> ADD TO CART
           </Button>
         </div>
       </div>
+      <div className={styles.content}>
+        <h5>{name}</h5>
+        <div className={styles.stars}>
+          {[1, 2, 3, 4, 5].map(i => (
+            <a key={i} href='#'>
+              {i <= stars ? (
+                <FontAwesomeIcon icon={faStar}>{i} stars</FontAwesomeIcon>
+              ) : (
+                <FontAwesomeIcon icon={farStar}>{i} stars</FontAwesomeIcon>
+              )}
+            </a>
+          ))}
+        </div>
+      </div>
+      <div className={styles.line}></div>
+      <div className={styles.actions}>
+        <div className={styles.outlines}>
+          <Button variant={isFavorite ? 'active' : 'outline'} onClick={changeFavorite}>
+            <FontAwesomeIcon icon={faHeart}>Favorite</FontAwesomeIcon>
+          </Button>
+          <Button variant={compare ? 'active' : 'outline'}>
+            <FontAwesomeIcon icon={faExchangeAlt}>Add to compare</FontAwesomeIcon>
+          </Button>
+        </div>
+        <div className={oldPrice ? styles.priceBox : ''}>
+          {oldPrice && <p>$ {oldPrice}</p>}
+          <div className={styles.price}>
+            <Button noHover variant='small' className={styles.priceButton}>
+              $ {price}
+            </Button>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 ProductBox.propTypes = {
   children: PropTypes.node,

--- a/src/components/common/ProductBox/ProductBox.test.js
+++ b/src/components/common/ProductBox/ProductBox.test.js
@@ -1,10 +1,16 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ProductBox from './ProductBox';
+import { Provider } from 'react-redux';
+import store from '../../../redux/store';
 
 describe('Component ProductBox', () => {
   it('should render without crashing', () => {
-    const component = shallow(<ProductBox />);
+    const component = shallow(
+      <Provider store={store}>
+        <ProductBox />
+      </Provider>
+    );
     expect(component).toBeTruthy();
   });
 });

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -212,6 +212,7 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      favorite: true,
     },
     {
       id: 'aenean-ru-bristique-23',

--- a/src/redux/productsRedux.js
+++ b/src/redux/productsRedux.js
@@ -5,7 +5,16 @@ export const getCount = ({ products }) => products.length;
 export const getNew = ({ products }) =>
   products.filter(item => item.newFurniture === true);
 
-export const setFavorite = payload => ({ type: 'SET_FAVORITE', payload });
+/* action name creator */
+const reducerName = 'products';
+const createActionName = name => `app/${reducerName}/${name}`;
+
+/* action types */
+const SET_FAVORITE = createActionName('SET_FAVORITE');
+
+/* action creators */
+export const setFavorite = payload => ({ type: SET_FAVORITE, payload });
+
 /* reducer */
 export default function reducer(statePart = [], action = {}) {
   switch (action.type) {

--- a/src/redux/productsRedux.js
+++ b/src/redux/productsRedux.js
@@ -5,9 +5,14 @@ export const getCount = ({ products }) => products.length;
 export const getNew = ({ products }) =>
   products.filter(item => item.newFurniture === true);
 
+export const setFavorite = payload => ({ type: 'SET_FAVORITE', payload });
 /* reducer */
 export default function reducer(statePart = [], action = {}) {
   switch (action.type) {
+    case 'SET_FAVORITE':
+      return statePart.map(product =>
+        product.id === action.payload.id ? { ...product, ...action.payload } : product
+      );
     default:
       return statePart;
   }


### PR DESCRIPTION
Brak funkcjonalności przycisku favorite.
Co najmniej jeden produkt ma mieć stan favorite po odświeżeniu strony.
Ulubiony przycisk ma przy stanie true wyglądać jak przy hover.

- Owinięcie komponentu w teście w wrapper <Provider store={store}>
- Dodanie nowego actioncreatora do obsługi stanu produktu.
- Dodanie funkcji handleFavorite z logiką redux do ProductBox
- Dodanie stanu favorite: true dla produktu przy odświeżeniu strony.
- Przycisk już wygląda jak przy hover.